### PR TITLE
Superscript numbers, boldface when non-zero

### DIFF
--- a/chrome/content/zotero/bindings/tab-counter.xml
+++ b/chrome/content/zotero/bindings/tab-counter.xml
@@ -44,7 +44,7 @@
 					var v = parseInt(val, 10);
 					if(!isNaN(v) && v >= 0) {
 						this.setAttribute('count', v);
-						document.getAnonymousElementByAttribute(this, 'class', 'tab-counter').value = '(' + v + ')';
+						document.getAnonymousElementByAttribute(this, 'class', 'tab-counter').value = v;
 					}
 				]]>
 				</setter>

--- a/chrome/skin/default/zotero/itemPane.css
+++ b/chrome/skin/default/zotero/itemPane.css
@@ -20,6 +20,20 @@
 	margin-bottom: .25em !important;
 }
 
+/* itemPane tabs with counters */
+tabbox#zotero-view-tabbox tab[type=counter] label.tab-counter {
+	width: 1.4em;
+	margin: 0em 0em 0em 0.3em;
+	font-size: 80%;
+	padding-bottom: 1ex;
+	font-weight: bold;
+}
+
+tabbox#zotero-view-tabbox tab[type=counter][count="0"] label.tab-counter {
+	color: #bbbbbb;
+	font-weight: normal;
+}
+
 #zotero-view-item
 {
 	padding: 1.5em .25em .25em;

--- a/chrome/skin/default/zotero/zotero.css
+++ b/chrome/skin/default/zotero/zotero.css
@@ -312,9 +312,3 @@ label.zotero-text-link {
 	padding-bottom: 4px;
 }
 
-/* itemPane tabs with counters */
-tabbox#zotero-view-tabbox tab[type=counter] label.tab-counter {
-	text-align: center;
-	width: 1.9em;
-	margin: 0em 0em 0em 0.2em
-}


### PR DESCRIPTION
The text colour alone wasn't very eye-catching. I fiddled around trying to find some way of providing a visual hint that wasn't too distracting, and came up with this. See what you think. 

(I moved the CSS to itemPane.css, so it could reside next to the other tab formatting blocks.)
