### PR TITLE
[COinS export]: Avoid exporting editors, translators, etc.

### DIFF
--- a/chrome/content/zotero/xpcom/openurl.js
+++ b/chrome/content/zotero/xpcom/openurl.js
@@ -203,25 +203,16 @@ Zotero.OpenURL = new function() {
 			}
 		}
 		
-		if(item.creators && item.creators.length) {
-			// encode first author as first and last
-			var firstCreator = item.creators[0];
-			if(item.itemType == "patent") {
-				_mapTag(firstCreator.firstName, "invfirst");
-				_mapTag(firstCreator.lastName, "invlast");
-			} else {
-				if(firstCreator.isInstitution) {
-					_mapTag(firstCreator.lastName, "aucorp");
-				} else {
-					_mapTag(firstCreator.firstName, "aufirst");
-					_mapTag(firstCreator.lastName, "aulast");
-				}
-			}
-			
-			// encode subsequent creators as au
-			for(var i=0; i<item.creators.length; i++) {
-				_mapTag((item.creators[i].firstName ? item.creators[i].firstName+" " : "")+
-					item.creators[i].lastName, (item.itemType == "patent" ? "inventor" : "au"));
+		// only export authors (more general primaryCreators)
+		// other creator types cannot correctly export to COinS
+		var itemTypeID = Zotero.ItemTypes.getID(item.itemType);
+		var primaryCreator = Zotero.CreatorTypes.getName(Zotero.CreatorTypes.getPrimaryIDForType(itemTypeID));
+		for(var i=0; i<item.creators.length; i++) {
+			var creator = item.creators[i];
+			if(creator.creatorType == primaryCreator) {
+				var tag = item.itemType == "patent" ? "inventor" : "au";
+				var value = creator.lastName + (creator.firstName ? ", " + creator.firstName : "");
+				_mapTag(value, tag);
 			}
 		}
 		


### PR DESCRIPTION
Discussed at https://forums.zotero.org/discussion/50880/every-contributor-exported-as-author-in-coins-export/#Item_0
- Contributors which are not authors, such as editors, translators etc., are not anymore exported to au, aufirst, aulast.
- These contributors cannot be saved in COinS format at all.
- Fixed export for corporate authors (aucorp).

This affects the COinS export as well as the OpenUrl resolving.
